### PR TITLE
fix some remote port will cause Invalid argument

### DIFF
--- a/dispatcher.py
+++ b/dispatcher.py
@@ -87,9 +87,6 @@ def udpDispatcher(server, destinations, subscribers, stop_event):
         # create a UDP socket to send with
         with socket(AF_INET, SOCK_DGRAM) as s:
 
-            # bind the socket to the UDP port
-            s.bind(server)
-
             while not stop_event.is_set():
                 try:
                     data = q.get(timeout=1)


### PR DESCRIPTION
When I set udp-dest for stream AIS data via UDP to MarineTraffic, will appear error like: `OSError: [Errno 22] Invalid argument`, But that will back to normal after remove s.bind(server) in udpDispatcher function.

#2 